### PR TITLE
Fixed missing 5-minute-old image.

### DIFF
--- a/src/leaflet-radar.js
+++ b/src/leaflet-radar.js
@@ -191,15 +191,18 @@ L.Control.Radar = L.Control.extend({
                 TOTAL_INTERVALS * INTERVAL_LENGTH_HRS -
                 INTERVAL_LENGTH_HRS * i;
 
-            if (timeDiffMins === 5) {
-                continue;
-            } // broken IDKY
+            const suffix = (function(time) {  
+                switch(time) {
+                    case 0:
+                        return '';
+                    case 5:
+                        return '-m05m';
+                    default:
+                        return '-m' + time + 'm';
+                }
+                })(timeDiffMins);
 
-            const layerRequest =
-                this.NEXRAD_LAYER +
-                (!!timeDiffMins
-                    ? `-m` + timeDiffMins + "m"
-                    : ``);
+            const layerRequest = this.NEXRAD_LAYER + suffix;
 
             const layer = L.tileLayer.wms(this.NEXRAD_URL, {
                 layers: layerRequest,


### PR DESCRIPTION
Made small change to allow the 5-minute-old layer to be downloaded. It was missing a leading 0 (nexrad-n0q-900913-m**0**5m). Thanks for this plugin!